### PR TITLE
Fix default wrapper behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Rehype plugin to transform fenced CSV code blocks into SVG charts.
  *
- * By default, this plugin preserves the original <pre><code> block alongside the generated chart.
+ * By default, this plugin removes the original <pre><code> block.
+ * Pass `saveOriginal: true` to keep it alongside the generated chart.
  *
  * @module rehypeTimeseriesChart
  */
@@ -198,17 +199,13 @@ export default function rehypeTimeseriesChart(options: ChartOptions = {}) {
       /* ---------------------------------------------------------------- */
       /* 8. Replace or wrap original node                                 */
       /* ---------------------------------------------------------------- */
-      if (saveOriginal) {
-        const container: HastElement = {
-          type: 'element',
-          tagName: 'div',
-          properties: { className: [containerClass] },
-          children: [svgNode, node],
-        };
-        parent.children.splice(idx, 1, container);
-      } else {
-        parent.children.splice(idx, 1, svgNode);
-      }
+      const container: HastElement = {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: [containerClass] },
+        children: saveOriginal ? [svgNode, node] : [svgNode],
+      };
+      parent.children.splice(idx, 1, container);
     });
   };
 }

--- a/test/rehype-timeseries-chart.test.js
+++ b/test/rehype-timeseries-chart.test.js
@@ -29,6 +29,11 @@ test('rehype: converts an HTML <code class="language-csv"> block into an <svg>',
   const result = String(out)
 
   // The plugin should have replaced the <code> block with an inline SVG chart
+  assert.match(
+    result,
+    /<div class="timeseries-chart-container">/,
+    'wrapper div should be present'
+  )
   assert.match(result, /<svg[^>]*>/, 'output should contain an <svg>')
   assert.doesNotMatch(
     result,
@@ -58,6 +63,11 @@ test('remark → rehype: converts a fenced ```csv block in Markdown into an <svg
   const result = String(out)
 
   assert.match(result, /<svg[^>]*>/, 'output should contain an <svg>')
+  assert.match(
+    result,
+    /<div class="timeseries-chart-container">/,
+    'wrapper div should be present'
+  )
   assert.doesNotMatch(
     result,
     /<code[^>]*language-csv/,


### PR DESCRIPTION
## Summary
- correct plugin comment about default `saveOriginal` setting
- always wrap generated charts in a `<div>` so `containerClass` is used
- update tests for wrapper div

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874a532d2488326bc9aaebf0ecf6443